### PR TITLE
IHS-24 - Category caraousel view all button removed

### DIFF
--- a/cms/components/CmsShopByCategory/CmsShopByCategory.tsx
+++ b/cms/components/CmsShopByCategory/CmsShopByCategory.tsx
@@ -103,7 +103,6 @@ const CmsHomePageCategory = (props: HomePageProps) => {
             <NavigateBeforeIcon />
           </IconButton>
         </Box>
-        <Box sx={ShopByCategoryStyle.viewAllText}>VIEW ALL</Box>
       </Box>
       <Grid container spacing={4} sx={ShopByCategoryStyle.gridContainer}>
         {items.slice(currentIndex, currentIndex + itemsPerPage).map((item: any) => (


### PR DESCRIPTION
Category Carousel - "VIEW ALL" button is not configured to be clickable and does not redirect user anywhere removed View all button link